### PR TITLE
LV0 프로젝트 세팅 - 에러분석

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/advanced
+    username: root
+    password: 210812
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+
+server:
+  error:
+    include-message: always
+    include-binding-errors: always
+
+jwt:
+  secret:
+    key: 8z5HfOeL4jYqGm6T9pB3Wc2sRvD8Xy1n0aKuZl9wTgM=


### PR DESCRIPTION
feat: add yml
fork - clone 후 테스트 결과 DB가 연결되지 않았다는 오류메세지를 확인했고,
yml을 생성해 MySQL 데이터베이스에 연결했습니다.
처음엔 연결만으로도 오류가 해결되지 않아 메세지를 더 찾아보니
JwtUtil의 jwt.secret.key의 값이 없어서였다는것을 알았습니다.
임의의 key를 입력해도 테스트 오류가 나와 더 찾아보니
Base64로 인코딩된 최소 256비트 이상이라는 조건이 있어
8z5HfOeL4jYqGm6T9pB3Wc2sRvD8Xy1n0aKuZl9wTgM= 입력후 테스트 실행에 성공했습니다.