### PR TITLE
LV3 N+1 문제

### DIFF
--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -3,6 +3,7 @@ package org.example.expert.domain.todo.repository;
 import org.example.expert.domain.todo.entity.Todo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +12,7 @@ import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
-    @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
+    @EntityGraph(attributePaths = {"user"})
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
 
     @Query("SELECT t FROM Todo t " +


### PR DESCRIPTION
-모든 Todo를 조회할 때, 각 Todo와 연관된 데이터를 개별적으로 가져오는 경우 N+1 문제가 발생할 수 있음 (과제 제시 내용)

-findAllByOrderByModifiedAtDesc에 @EntityGraph를 사용, attributePaths로 Todo 엔티티의 user 필드 조회

-이렇게 Todo마다 User를 조회하는 N+1 문제 해결